### PR TITLE
Make body more readable

### DIFF
--- a/src/auth.cr
+++ b/src/auth.cr
@@ -20,7 +20,7 @@ module Auth
 
     request = HTTP::Client.post(uri,
       headers: HTTP::Headers{"content-type" => "application/json"},
-      body: "{\"grant_type\":\"authorization_code\",\"client_id\": \"[CLIENT_ID]\",\"client_secret\": \"[CLIENT_SECRET]\",\"code\": \"#{id}\",\"redirect_uri\": \"http://localhost:6969/auth/callback\"}")
+      body: %{{"grant_type":"authorization_code","client_id": "[CLIENT_ID]","client_secret": "[CLIENT_SECRET]","code": "#{id}","redirect_uri": "http://localhost:6969/auth/callback"}})
 
     response = request.body
 


### PR DESCRIPTION
Hi @rbnpercy 😄 

This PR removes quote escaping `\"` using `%{}` for body string

see: https://crystal-lang.org/docs/syntax_and_semantics/literals/string.html